### PR TITLE
use CID instead of Text params for remote methods

### DIFF
--- a/library/Network/IPFS/Pin.hs
+++ b/library/Network/IPFS/Pin.hs
@@ -18,12 +18,12 @@ add ::
   )
   => IPFS.CID
   -> m (Either IPFS.Add.Error CID)
-add (CID hash) = ipfsPin hash >>= \case
+add cid = ipfsPin cid >>= \case
   Right Pin.Response { cids } ->
     case cids of
-      [cid] -> do
-        logDebug <| "Pinned CID " <> display hash
-        return <| Right cid
+      [cid'] -> do
+        logDebug <| "Pinned CID " <> display cid'
+        return <| Right cid'
 
       _ ->
         logLeft <| UnexpectedOutput <| UTF8.textShow cids
@@ -39,18 +39,18 @@ rm ::
   )
   => IPFS.CID
   -> m (Either IPFS.Add.Error CID)
-rm cid@(CID hash) = ipfsUnpin hash False >>= \case
+rm cid = ipfsUnpin cid False >>= \case
   Right Pin.Response { cids } ->
     case cids of
       [cid'] -> do
-        logDebug <| "Pinned CID " <> display hash
+        logDebug <| "Pinned CID " <> display cid'
         return <| Right cid'
 
       _ ->
         logLeft <| UnexpectedOutput <| UTF8.textShow cids
 
   Left _ -> do
-    logDebug <| "Cannot unpin CID " <> display hash <> " because it was not pinned"
+    logDebug <| "Cannot unpin CID " <> display cid <> " because it was not pinned"
     return <| Right cid
 
 logLeft ::

--- a/library/Network/IPFS/Remote/Class.hs
+++ b/library/Network/IPFS/Remote/Class.hs
@@ -21,11 +21,11 @@ import qualified Network.IPFS.File.Types      as File
 class Monad m => MonadRemoteIPFS m where
   runRemote :: ClientM a -> m(Either ClientError a)
   ipfsAdd   :: Lazy.ByteString -> m (Either ClientError CID)
-  ipfsCat   :: Text            -> m (Either ClientError File.Serialized)
-  ipfsPin   :: Text            -> m (Either ClientError Pin.Response)
-  ipfsUnpin :: Text -> Bool    -> m (Either ClientError Pin.Response)
+  ipfsCat   :: CID            -> m (Either ClientError File.Serialized)
+  ipfsPin   :: CID            -> m (Either ClientError Pin.Response)
+  ipfsUnpin :: CID -> Bool    -> m (Either ClientError Pin.Response)
   -- defaults
-  ipfsAdd raw             = runRemote <| IPFS.Client.add raw
-  ipfsCat cid             = runRemote <| IPFS.Client.cat cid
-  ipfsPin cid             = runRemote <| IPFS.Client.pin cid
-  ipfsUnpin cid recursive = runRemote <| IPFS.Client.unpin cid recursive
+  ipfsAdd raw                   = runRemote <| IPFS.Client.add raw
+  ipfsCat (CID cid)             = runRemote <| IPFS.Client.cat cid
+  ipfsPin (CID cid)             = runRemote <| IPFS.Client.pin cid
+  ipfsUnpin (CID cid) recursive = runRemote <| IPFS.Client.unpin cid recursive


### PR DESCRIPTION
## Problem
The remote class accepts arbitrary `Text`. Both for reasons of documentation, and ensuring that we're expressing our intent, this should be strengthened at the type level.

## Solution
Use the existing `CID` type instead of `Text`

https://github.com/fission-suite/ipfs-haskell/issues/5