### PR TITLE
remove spaces in NamedSchema for Swagger

### DIFF
--- a/library/Network/IPFS/CID/Types.hs
+++ b/library/Network/IPFS/CID/Types.hs
@@ -39,7 +39,7 @@ instance ToSchema CID where
     mempty
       |> type_   ?~ SwaggerString
       |> example ?~ "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
-      |> NamedSchema (Just "IPFS Address")
+      |> NamedSchema (Just "IPFSAddress")
       |> pure
 
 instance Display CID where

--- a/library/Network/IPFS/File/Types.hs
+++ b/library/Network/IPFS/File/Types.hs
@@ -21,7 +21,7 @@ instance ToSchema Serialized where
       |> example     ?~ "hello world"
       |> description ?~ "A typical file's contents"
       |> type_       ?~ SwaggerString
-      |> NamedSchema (Just "Serialized File")
+      |> NamedSchema (Just "SerializedFile")
       |> pure
 
 instance Display Serialized where

--- a/library/Network/IPFS/Peer/Types.hs
+++ b/library/Network/IPFS/Peer/Types.hs
@@ -23,7 +23,7 @@ instance ToJSON Peer where
 
 instance ToSchema Peer where
   declareNamedSchema _ =
-     return $ NamedSchema (Just "IPFS Peer") $ mempty
+     return $ NamedSchema (Just "IPFSPeer") $ mempty
             & type_       ?~ SwaggerString
             & example     ?~ "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd"
             & description ?~ "An IPFS peer address"

--- a/library/Network/IPFS/SparseTree/Types.hs
+++ b/library/Network/IPFS/SparseTree/Types.hs
@@ -38,7 +38,7 @@ instance ToSchema SparseTree where
       |> type_       ?~ SwaggerString
       |> description ?~ "A tree of IPFS paths"
       |> example     ?~ toJSON (Directory [(Key "abcdef", Stub "myfile.txt")])
-      |> NamedSchema (Just "IPFS Tree")
+      |> NamedSchema (Just "IPFSTree")
       |> pure
 
 instance Display (Map Tag SparseTree) where


### PR DESCRIPTION
## Problem
https://github.com/fission-suite/web-api/pull/213 removed spaces in `NamedSchema` names for swagger docs for a few types.

## Solution
Move these changes over to `ipfs-haskell` since I'm rebasing the web-api. 