### PR TITLE
Generalize logging to monad-logger

### DIFF
--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 110aba584304ee2f3985a46afe07b910ad681ad299577306b3e62a2fba874ee2
+-- hash: 80dd7eb66526a5a58adb405fded6b0e0d0bb3cdc5d3beb9b1c4440c7f82b0a15
 
 name:           ipfs
 version:        1.0.0
@@ -56,6 +56,7 @@ library
       Network.IPFS.Internal.Constraint
       Network.IPFS.Internal.Orphanage.ByteString.Lazy
       Network.IPFS.Internal.Orphanage.Natural
+      Network.IPFS.Internal.Orphanage.Utf8Builder
       Network.IPFS.Internal.UTF8
       Network.IPFS.Local.Class
       Network.IPFS.Name.Types
@@ -92,6 +93,7 @@ library
     , http-client
     , ip
     , lens
+    , monad-logger
     , regex-compat
     , rio
     , servant-client
@@ -127,6 +129,7 @@ test-suite fission-doctest
     , ip
     , lens
     , lens-aeson
+    , monad-logger
     , regex-compat
     , rio
     , servant-client

--- a/library/Network/IPFS/Internal/Orphanage/Utf8Builder.hs
+++ b/library/Network/IPFS/Internal/Orphanage/Utf8Builder.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Network.IPFS.Internal.Orphanage.Utf8Builder () where
+
+import RIO
+
+import Control.Monad.Logger
+
+instance ToLogStr Utf8Builder where
+  toLogStr (Utf8Builder builder) = toLogStr builder

--- a/library/Network/IPFS/Pin.hs
+++ b/library/Network/IPFS/Pin.hs
@@ -12,9 +12,8 @@ import           Network.IPFS.Add.Error      as IPFS.Add
 import           Network.IPFS.Types          as IPFS
 
 add ::
-  ( MonadRIO        cfg m
-  , MonadRemoteIPFS     m
-  , HasLogFunc      cfg
+  ( MonadRemoteIPFS m
+  , MonadLogger     m
   )
   => IPFS.CID
   -> m (Either IPFS.Add.Error CID)
@@ -33,9 +32,8 @@ add cid = ipfsPin cid >>= \case
 
 -- | Unpin a CID
 rm ::
-  ( MonadRIO        cfg m
-  , MonadRemoteIPFS     m
-  , HasLogFunc      cfg
+  ( MonadRemoteIPFS  m
+  , MonadLogger      m
   )
   => IPFS.CID
   -> m (Either IPFS.Add.Error CID)
@@ -54,8 +52,7 @@ rm cid = ipfsUnpin cid False >>= \case
     return <| Right cid
 
 logLeft ::
-  ( MonadRIO cfg m
-  , HasLogFunc cfg
+  ( MonadLogger m
   , Show a
   )
   => a

--- a/library/Network/IPFS/Prelude.hs
+++ b/library/Network/IPFS/Prelude.hs
@@ -1,6 +1,7 @@
 -- | A custom @Prelude@-like module for this project
 module Network.IPFS.Prelude
   ( module Control.Lens
+  , module Control.Monad.Logger
   , module Data.Aeson
   , module Data.Has
   , module Network.IPFS.Internal.Constraint
@@ -8,16 +9,57 @@ module Network.IPFS.Prelude
   , module RIO
   , module RIO.Process
   , identity
+  , logInfo
+  , logDebug
+  , logWarn
+  , logError
+  , logOther
   ) where
 
-import Control.Lens                ((%~), (.~), (?~), (^?))
+import Control.Lens         ((%~), (.~), (?~), (^?))
+import Control.Monad.Logger (MonadLogger (..), ToLogStr (..), LogLevel (..), logWithoutLoc)
 import Data.Aeson
 import Data.Has
+
 import Network.IPFS.Internal.Constraint
+import Network.IPFS.Internal.Orphanage.Utf8Builder ()
 
 import Flow
-import RIO                         hiding (Handler, id, timeout, ($), (&))
+
 import RIO.Process
+import RIO hiding ( Handler
+                  , LogLevel (..)
+                  , LogSource
+                  , logDebug
+                  , logDebugS
+                  , logError
+                  , logErrorS
+                  , logInfo
+                  , logInfoS
+                  , logOther
+                  , logOtherS
+                  , logWarn
+                  , logWarnS
+                  , id
+                  , timeout
+                  , ($)
+                  , (&)
+                  )
 
 identity :: a -> a
 identity a = a
+
+logInfo :: (ToLogStr msg, MonadLogger m) => msg -> m ()
+logInfo = logWithoutLoc "" LevelInfo
+
+logDebug :: (ToLogStr msg, MonadLogger m) => msg -> m ()
+logDebug = logWithoutLoc "" LevelDebug
+
+logWarn :: (ToLogStr msg, MonadLogger m) => msg -> m ()
+logWarn = logWithoutLoc "" LevelWarn
+
+logError :: (ToLogStr msg, MonadLogger m) => msg -> m ()
+logError = logWithoutLoc "" LevelError
+
+logOther :: (ToLogStr msg, MonadLogger m) => LogLevel -> msg -> m ()
+logOther = logWithoutLoc ""

--- a/package.yaml
+++ b/package.yaml
@@ -86,6 +86,7 @@ dependencies:
   - http-client
   - ip
   - lens
+  - monad-logger
   - regex-compat
   - rio
   - servant-client


### PR DESCRIPTION
I believe that this was the only remaining library module with `MonadRIO cfg` that doesn't strictly need it.

Here it's generalized to `MonadLogger`. This helps us stage for some changes coming in the Web API 🎉