### PR TITLE
Improve IPFS error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -556,10 +556,6 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "explorer.compactFolders": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "explorer.compactFolders": false
+}

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -97,6 +97,7 @@ library
     , regex-compat
     , rio
     , servant-client
+    , servant-client-core
     , servant-multipart
     , servant-server
     , swagger2
@@ -133,6 +134,7 @@ test-suite fission-doctest
     , regex-compat
     , rio
     , servant-client
+    , servant-client-core
     , servant-multipart
     , servant-server
     , swagger2

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -39,6 +39,7 @@ library
       Network.IPFS.Client
       Network.IPFS.Client.Add
       Network.IPFS.Client.Cat
+      Network.IPFS.Client.Error.Types
       Network.IPFS.Client.Param
       Network.IPFS.Client.Pin
       Network.IPFS.Config

--- a/library/Network/IPFS/Add/Error.hs
+++ b/library/Network/IPFS/Add/Error.hs
@@ -21,5 +21,5 @@ instance Display Error where
     InvalidFile          -> "Invalid file"
     UnexpectedOutput txt -> "Unexpected IPFS output: " <> display txt
     RecursiveAddErr  err -> "Error while adding directory" <> display err
-    IPFSDaemonErr    txt -> "IPFS Daemon error:" <> display txt -- TODO: Move this type to it's own file
+    IPFSDaemonErr    txt -> "IPFS Daemon error: " <> display txt
     UnknownAddErr    txt -> "Unknown IPFS add error: " <> display txt

--- a/library/Network/IPFS/Add/Error.hs
+++ b/library/Network/IPFS/Add/Error.hs
@@ -7,7 +7,7 @@ data Error
   = InvalidFile
   | UnexpectedOutput Text
   | RecursiveAddErr Get.Error
-  | KnownAddErr Text
+  | IPFSDaemonErr Text
   | UnknownAddErr Text
   deriving ( Exception
            , Eq
@@ -21,5 +21,5 @@ instance Display Error where
     InvalidFile          -> "Invalid file"
     UnexpectedOutput txt -> "Unexpected IPFS output: " <> display txt
     RecursiveAddErr  err -> "Error while adding directory" <> display err
-    KnownAddErr      txt -> "IPFS add error:" <> display txt
+    IPFSDaemonErr    txt -> "IPFS Daemon error:" <> display txt
     UnknownAddErr    txt -> "Unknown IPFS add error: " <> display txt

--- a/library/Network/IPFS/Add/Error.hs
+++ b/library/Network/IPFS/Add/Error.hs
@@ -21,5 +21,5 @@ instance Display Error where
     InvalidFile          -> "Invalid file"
     UnexpectedOutput txt -> "Unexpected IPFS output: " <> display txt
     RecursiveAddErr  err -> "Error while adding directory" <> display err
-    IPFSDaemonErr    txt -> "IPFS Daemon error:" <> display txt
+    IPFSDaemonErr    txt -> "IPFS Daemon error:" <> display txt -- TODO: Move this type to it's own file
     UnknownAddErr    txt -> "Unknown IPFS add error: " <> display txt

--- a/library/Network/IPFS/Add/Error.hs
+++ b/library/Network/IPFS/Add/Error.hs
@@ -7,6 +7,7 @@ data Error
   = InvalidFile
   | UnexpectedOutput Text
   | RecursiveAddErr Get.Error
+  | KnownAddErr Text
   | UnknownAddErr Text
   deriving ( Exception
            , Eq
@@ -20,4 +21,5 @@ instance Display Error where
     InvalidFile          -> "Invalid file"
     UnexpectedOutput txt -> "Unexpected IPFS output: " <> display txt
     RecursiveAddErr  err -> "Error while adding directory" <> display err
+    KnownAddErr      txt -> "IPFS add error:" <> display txt
     UnknownAddErr    txt -> "Unknown IPFS add error: " <> display txt

--- a/library/Network/IPFS/Client/Error/Types.hs
+++ b/library/Network/IPFS/Client/Error/Types.hs
@@ -1,0 +1,8 @@
+module Network.IPFS.Client.Error.Types (ErrorBody (..)) where
+import Network.IPFS.Prelude
+
+data ErrorBody = ErrorBody {message :: String}
+instance FromJSON ErrorBody where
+  parseJSON = withObject "ErrorBody" \obj -> do
+    message    <- obj .: "Message"
+    return <| ErrorBody {..}

--- a/library/Network/IPFS/Client/Error/Types.hs
+++ b/library/Network/IPFS/Client/Error/Types.hs
@@ -1,8 +1,10 @@
 module Network.IPFS.Client.Error.Types (ErrorBody (..)) where
+
 import Network.IPFS.Prelude
 
 data ErrorBody = ErrorBody {message :: String}
+
 instance FromJSON ErrorBody where
   parseJSON = withObject "ErrorBody" \obj -> do
     message    <- obj .: "Message"
-    return <| ErrorBody {..}
+    return ErrorBody {..}

--- a/library/Network/IPFS/Pin.hs
+++ b/library/Network/IPFS/Pin.hs
@@ -29,11 +29,11 @@ add cid = ipfsPin cid >>= \case
 
       _ -> do
         formattedErr <- parseUnexpectedOutput <| UTF8.textShow cids
-        return <| Left <| formattedErr
+        return <| Left formattedErr
 
   Left err -> do
     formattedError <- parseClientError err
-    return <| Left <| formattedError
+    return <| Left formattedError
 
 -- | Unpin a CID
 rm ::
@@ -52,7 +52,7 @@ rm cid = ipfsUnpin cid False >>= \case
 
       _ -> do
         formattedErr <- parseUnexpectedOutput <| UTF8.textShow cids
-        return <| Left <| formattedErr
+        return <| Left formattedErr
 
   Left _ -> do
     logDebug <| "Cannot unpin CID " <> display cid <> " because it was not pinned"

--- a/library/Network/IPFS/Pin.hs
+++ b/library/Network/IPFS/Pin.hs
@@ -21,7 +21,8 @@ instance FromJSON IPFSErrorBody where
 
 -- | Pin a CID
 add ::
-  ( MonadRemoteIPFS m
+  ( MonadRIO cfg m
+  , MonadRemoteIPFS m
   , MonadLogger     m
   )
   => IPFS.CID
@@ -43,7 +44,8 @@ add cid = ipfsPin cid >>= \case
 
 -- | Unpin a CID
 rm ::
-  ( MonadRemoteIPFS  m
+  ( MonadRIO cfg m
+  , MonadRemoteIPFS  m
   , MonadLogger      m
   )
   => IPFS.CID
@@ -66,7 +68,7 @@ rm cid = ipfsUnpin cid False >>= \case
 -- | Parse and Log the Servant Client Error returned from the IPFS Daemon
 parseClientError ::
   ( MonadRIO        cfg m
-  , HasLogFunc      cfg
+  , MonadLogger     m
   )
   => ClientError
   -> m (Error)
@@ -92,7 +94,7 @@ parseClientError err = do
 -- | Parse and Log unexpected output when attempting to pin
 parseUnexpectedOutput ::
   ( MonadRIO cfg m
-  , HasLogFunc cfg
+  , MonadLogger m
   )
   => Text
   -> m (IPFS.Add.Error)

--- a/library/Network/IPFS/Pin.hs
+++ b/library/Network/IPFS/Pin.hs
@@ -47,7 +47,7 @@ rm cid = ipfsUnpin cid False >>= \case
   Right Pin.Response { cids } ->
     case cids of
       [cid'] -> do
-        logDebug <| "Pinned CID " <> display cid'
+        logDebug <| "Unpinned CID " <> display cid'
         return <| Right cid'
 
       _ -> do
@@ -67,8 +67,8 @@ parseClientError ::
   -> m Error
 parseClientError err = do
   logError <| displayShow err
-  let newError = case err of
-        (FailureResponse _ response) ->
+  return <| case err of
+        FailureResponse _ response ->
           response
           |> responseBody
           |> decode
@@ -82,8 +82,6 @@ parseClientError err = do
         unknownClientError ->
           UnknownAddErr <| UTF8.textShow unknownClientError
 
-  return newError
-
 -- | Parse and Log unexpected output when attempting to pin
 parseUnexpectedOutput ::
   ( MonadRIO cfg m
@@ -92,7 +90,9 @@ parseUnexpectedOutput ::
   => Text
   -> m IPFS.Add.Error
 parseUnexpectedOutput errStr = do
-  let baseError = UnexpectedOutput errStr
-  let err = UnknownAddErr <| UTF8.textShow <| baseError
+  let
+    baseError = UnexpectedOutput errStr
+    err = UnknownAddErr <| UTF8.textShow baseError
+
   logError <| display baseError
   return err

--- a/library/Network/IPFS/Types.hs
+++ b/library/Network/IPFS/Types.hs
@@ -15,6 +15,7 @@ module Network.IPFS.Types
   , URL (..)
   , Ignored
   , Gateway (..)
+  , ErrorBody (..)
   ) where
 
 import Network.IPFS.BinPath.Types
@@ -28,3 +29,4 @@ import Network.IPFS.Timeout.Types
 import Network.IPFS.URL.Types
 import Network.IPFS.Ignored.Types
 import Network.IPFS.Gateway.Types
+import Network.IPFS.Client.Error.Types

--- a/package.yaml
+++ b/package.yaml
@@ -90,6 +90,7 @@ dependencies:
   - regex-compat
   - rio
   - servant-client
+  - servant-client-core
   - servant-multipart
   - servant-server
   - swagger2


### PR DESCRIPTION
## Summary
There is often useful information in the response body from IPFS Daemon errors. info that could help uses debug why their request failed. Like an invalid CID.

This PR adds a new error type containing the IPFS Daemon Error message. Useful for Web-api to forward onto it's users.

![image](https://user-images.githubusercontent.com/1325608/70840188-db1f8a80-1dcd-11ea-9283-76ec97954690.png)


## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

