### PR TITLE
Hotfix go-ipfs 0.5.x compatability

### DIFF
--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -1,13 +1,13 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 17a591e896885291287dff968449557567166ad742b2bc44bcddf6ec2522f03d
+-- hash: 9ed6b01b56d1d0c1aa8f9fe456f538e8fe6bec8bc9bad95f54741a0b89025112
 
 name:           ipfs
-version:        1.0.2
+version:        1.0.3
 synopsis:       Access IPFS locally and remotely
 description:    Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category:       Network
@@ -87,7 +87,7 @@ library
   build-depends:
       Glob
     , aeson
-    , base
+    , base <5
     , bytestring
     , envy
     , flow
@@ -116,7 +116,7 @@ test-suite fission-doctest
       Glob
     , QuickCheck
     , aeson
-    , base
+    , base <5
     , bytestring
     , directory
     , directory-tree

--- a/library/Network/IPFS/Client/Pin.hs
+++ b/library/Network/IPFS/Client/Pin.hs
@@ -7,16 +7,16 @@ module Network.IPFS.Client.Pin
 
 import Servant
 
-import           Network.IPFS.Prelude
 import           Network.IPFS.CID.Types
 import qualified Network.IPFS.Client.Param as Param
+import           Network.IPFS.Prelude
 
 type API = AddAPI :<|> RemoveAPI
 
 type AddAPI
   = "add"
     :> Param.CID
-    :> Put '[JSON] Response
+    :> Post '[JSON] Response
 
 type RemoveAPI
   = "rm"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: ipfs
-version: '1.0.2'
+version: '1.0.3'
 synopsis: Access IPFS locally and remotely
 description: Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category: Network


### PR DESCRIPTION
`go-ipfs` now appears to enforce specific HTTP methods. They're not all the methods that would conform REST, but it's still a step up 😉 