### PR TITLE
Add stat to ipfs remote api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![](https://github.com/fission-suite/PROJECTNAME/raw/master/assets/logo.png?sanitize=true)
-
 # ipfs-haskell
 
 [![Build Status](https://travis-ci.org/fission-suite/PROJECTNAME.svg?branch=master)](https://travis-ci.org/fission-suite/ipfs-haskell)

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9ed6b01b56d1d0c1aa8f9fe456f538e8fe6bec8bc9bad95f54741a0b89025112
+-- hash: d79f28e406228fbeaa7826c3fac340acbbf0d3a3107faa904cb50ef8eb5d6e45
 
 name:           ipfs
 version:        1.0.3
@@ -44,6 +44,7 @@ library
       Network.IPFS.Client.Error.Types
       Network.IPFS.Client.Param
       Network.IPFS.Client.Pin
+      Network.IPFS.Client.Stat
       Network.IPFS.DAG
       Network.IPFS.DAG.Link
       Network.IPFS.DAG.Link.Types
@@ -74,6 +75,7 @@ library
       Network.IPFS.SparseTree
       Network.IPFS.SparseTree.Types
       Network.IPFS.Stat
+      Network.IPFS.Stat.Types
       Network.IPFS.Timeout.Types
       Network.IPFS.Types
       Network.IPFS.URL.Types

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 87a81f37a3356aa9b7dc76bdc68728f4a20aa0918e378802565fe0329cff619a
+-- hash: 71fe6bdbacb97fbf90cb0fdb685eb89f0a33a63529b54e223bb7c5b89c99fc03
 
 name:           ipfs
 version:        1.0.3
@@ -37,6 +37,7 @@ library
       Network.IPFS.Add
       Network.IPFS.Add.Error
       Network.IPFS.BinPath.Types
+      Network.IPFS.Bytes.Types
       Network.IPFS.CID.Types
       Network.IPFS.Client
       Network.IPFS.Client.Add

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d79f28e406228fbeaa7826c3fac340acbbf0d3a3107faa904cb50ef8eb5d6e45
+-- hash: 87a81f37a3356aa9b7dc76bdc68728f4a20aa0918e378802565fe0329cff619a
 
 name:           ipfs
 version:        1.0.3

--- a/library/Network/IPFS/Bytes/Types.hs
+++ b/library/Network/IPFS/Bytes/Types.hs
@@ -1,0 +1,13 @@
+module Network.IPFS.Bytes.Types (Bytes(..)) where
+
+import           Network.IPFS.Prelude
+
+newtype Bytes = Bytes { unBytes :: Natural }
+  deriving newtype ( Eq
+                   , Show
+                   )
+
+instance FromJSON Bytes where
+  parseJSON val = do
+    nat <- parseJSON val
+    return <| Bytes nat

--- a/library/Network/IPFS/Client.hs
+++ b/library/Network/IPFS/Client.hs
@@ -2,6 +2,7 @@ module Network.IPFS.Client
   ( API
   , add
   , cat
+  , stat
   , pin
   , unpin
   ) where
@@ -15,25 +16,31 @@ import           Network.IPFS.Internal.Orphanage.ByteString.Lazy ()
 
 import qualified Network.IPFS.File.Types      as File
 import           Network.IPFS.CID.Types
+import           Network.IPFS.Stat.Types
 
-import qualified Network.IPFS.Client.Add as Add
-import qualified Network.IPFS.Client.Cat as Cat
-import qualified Network.IPFS.Client.Pin as Pin
+import qualified Network.IPFS.Client.Add    as Add
+import qualified Network.IPFS.Client.Cat    as Cat
+import qualified Network.IPFS.Client.Pin    as Pin
+import qualified Network.IPFS.Client.Stat as Stat
 
 type API
   = "api"
   :> "v0"
   :> V0API
 
-type V0API = "add" :> Add.API
-        :<|> "cat" :> Cat.API
-        :<|> "pin" :> Pin.API
+type V0API = "add"  :> Add.API
+        :<|> "cat"  :> Cat.API
+        :<|> "stat" :> Stat.API
+        :<|> "pin"  :> Pin.API
 
 add   :: Lazy.ByteString -> ClientM CID
 cat   :: Text            -> ClientM File.Serialized
+stat  :: Text            -> ClientM Stat
 pin   :: Text            -> ClientM Pin.Response
 unpin :: Text -> Bool    -> ClientM Pin.Response
 
 add :<|> cat
+    :<|> stat 
     :<|> pin
-    :<|> unpin = client <| Proxy @API
+    :<|> unpin 
+    = client <| Proxy @API

--- a/library/Network/IPFS/Client/Stat.hs
+++ b/library/Network/IPFS/Client/Stat.hs
@@ -1,0 +1,10 @@
+module Network.IPFS.Client.Stat (API) where
+
+import Servant
+
+import           Network.IPFS.Stat.Types
+import qualified Network.IPFS.Client.Param as Param
+
+type API = "stat"
+        :> Param.CID
+        :> Get '[JSON] Stat

--- a/library/Network/IPFS/Remote/Class.hs
+++ b/library/Network/IPFS/Remote/Class.hs
@@ -18,7 +18,7 @@ import           Network.IPFS.Types as IPFS
 import qualified Network.IPFS.Client as IPFS.Client
 import qualified Network.IPFS.Client.Pin as Pin
 import qualified Network.IPFS.File.Types      as File
-import           Network.IPFS.Stat.Types
+
 
 class MonadIO m => MonadRemoteIPFS m where
   runRemote :: ClientM a       -> m (Either ClientError a)

--- a/library/Network/IPFS/Remote/Class.hs
+++ b/library/Network/IPFS/Remote/Class.hs
@@ -3,6 +3,7 @@ module Network.IPFS.Remote.Class
   , runRemote
   , ipfsAdd
   , ipfsCat
+  , ipfsStat
   , ipfsPin
   , ipfsUnpin
   ) where
@@ -17,16 +18,19 @@ import           Network.IPFS.Types as IPFS
 import qualified Network.IPFS.Client as IPFS.Client
 import qualified Network.IPFS.Client.Pin as Pin
 import qualified Network.IPFS.File.Types      as File
+import           Network.IPFS.Stat.Types
 
 class MonadIO m => MonadRemoteIPFS m where
   runRemote :: ClientM a       -> m (Either ClientError a)
   ipfsAdd   :: Lazy.ByteString -> m (Either ClientError CID)
   ipfsCat   :: CID             -> m (Either ClientError File.Serialized)
+  ipfsStat  :: CID             -> m (Either ClientError Stat)
   ipfsPin   :: CID             -> m (Either ClientError Pin.Response)
   ipfsUnpin :: CID -> Bool     -> m (Either ClientError Pin.Response)
 
   -- defaults
   ipfsAdd raw                   = runRemote <| IPFS.Client.add raw
-  ipfsCat   (CID cid)           = runRemote <| IPFS.Client.cat cid
-  ipfsPin   (CID cid)           = runRemote <| IPFS.Client.pin cid
+  ipfsCat (CID cid)             = runRemote <| IPFS.Client.cat cid
+  ipfsStat (CID cid)            = runRemote <| IPFS.Client.stat cid
+  ipfsPin (CID cid)             = runRemote <| IPFS.Client.pin cid
   ipfsUnpin (CID cid) recursive = runRemote <| IPFS.Client.unpin cid recursive

--- a/library/Network/IPFS/Stat.hs
+++ b/library/Network/IPFS/Stat.hs
@@ -20,6 +20,7 @@ import qualified Network.IPFS.Process.Error as Process
 
 import           Network.IPFS.Types as IPFS
 import           Network.IPFS.Stat.Types 
+import           Network.IPFS.Bytes.Types 
 
 getStatRemote :: 
      MonadRemoteIPFS m
@@ -36,7 +37,7 @@ getStatRemote cid =
 getSizeRemote :: 
      MonadRemoteIPFS m
   => IPFS.CID 
-  -> m (Either IPFS.Get.Error Natural)
+  -> m (Either IPFS.Get.Error Bytes)
 getSizeRemote cid = 
   getStatRemote cid >>= \case
     Left err -> return <| Left err

--- a/library/Network/IPFS/Stat.hs
+++ b/library/Network/IPFS/Stat.hs
@@ -1,5 +1,6 @@
 module Network.IPFS.Stat 
   ( getStatRemote
+  , getSizeRemote
   , getSize
   , module Network.IPFS.Stat.Types
   ) where
@@ -24,12 +25,22 @@ getStatRemote ::
      MonadRemoteIPFS m
   => IPFS.CID 
   -> m (Either IPFS.Get.Error Stat)
-getStatRemote cid = Remote.ipfsStat cid >>= \case
-  Left err -> 
-    return . Left . UnexpectedOutput <| UTF8.textShow err
+getStatRemote cid = 
+  Remote.ipfsStat cid >>= \case
+    Left err -> 
+      return . Left . UnexpectedOutput <| UTF8.textShow err
 
-  Right stat -> 
-    return <| Right stat
+    Right stat -> 
+      return <| Right stat
+
+getSizeRemote :: 
+     MonadRemoteIPFS m
+  => IPFS.CID 
+  -> m (Either IPFS.Get.Error Natural)
+getSizeRemote cid = 
+  getStatRemote cid >>= \case
+    Left err -> return <| Left err
+    Right stat -> return . Right <| cumulativeSize stat
 
 getSize ::
   MonadLocalIPFS m

--- a/library/Network/IPFS/Stat.hs
+++ b/library/Network/IPFS/Stat.hs
@@ -1,4 +1,7 @@
-module Network.IPFS.Stat (getSize) where
+module Network.IPFS.Stat 
+  ( getStatRemote
+  , getSize
+  ) where
 
 import           Data.ByteString.Lazy.Char8 as CL
 import           Data.List as List
@@ -7,11 +10,23 @@ import qualified RIO.ByteString.Lazy as Lazy
 
 import           Network.IPFS.Prelude
 import           Network.IPFS.Local.Class   as IPFS
+import           Network.IPFS.Remote.Class  as Remote
 import qualified Network.IPFS.Internal.UTF8 as UTF8
 
 import           Network.IPFS.Get.Error as IPFS.Get
 import qualified Network.IPFS.Process.Error as Process
 import           Network.IPFS.Types     as IPFS
+
+getStatRemote :: 
+     MonadRemoteIPFS m
+  => IPFS.CID 
+  -> m (Either IPFS.Get.Error Stat)
+getStatRemote cid = Remote.ipfsStat cid >>= \case
+  Left err -> 
+    return . Left . UnexpectedOutput <| UTF8.textShow err
+
+  Right stat -> 
+    return <| Right stat
 
 getSize ::
   MonadLocalIPFS m

--- a/library/Network/IPFS/Stat.hs
+++ b/library/Network/IPFS/Stat.hs
@@ -1,6 +1,7 @@
 module Network.IPFS.Stat 
   ( getStatRemote
   , getSize
+  , module Network.IPFS.Stat.Types
   ) where
 
 import           Data.ByteString.Lazy.Char8 as CL
@@ -13,9 +14,11 @@ import           Network.IPFS.Local.Class   as IPFS
 import           Network.IPFS.Remote.Class  as Remote
 import qualified Network.IPFS.Internal.UTF8 as UTF8
 
-import           Network.IPFS.Get.Error as IPFS.Get
+import           Network.IPFS.Get.Error     as IPFS.Get
 import qualified Network.IPFS.Process.Error as Process
-import           Network.IPFS.Types     as IPFS
+
+import           Network.IPFS.Types as IPFS
+import           Network.IPFS.Stat.Types 
 
 getStatRemote :: 
      MonadRemoteIPFS m

--- a/library/Network/IPFS/Stat/Types.hs
+++ b/library/Network/IPFS/Stat/Types.hs
@@ -1,0 +1,24 @@
+module Network.IPFS.Stat.Types (Stat(..)) where
+
+import Network.IPFS.Prelude
+
+
+data Stat = Stat 
+  { blockSize      :: Natural
+  , cumulativeSize :: Natural
+  , dataSize       :: Natural
+  , hash           :: Text
+  , linksSize      :: Natural
+  , numLinks       :: Natural
+  }
+
+instance FromJSON Stat where
+  parseJSON = withObject "Stat" \obj -> do
+    blockSize      <- obj .: "BlockSize"
+    cumulativeSize <- obj .: "CumulativeSize"
+    dataSize       <- obj .: "DataSize"
+    hash           <- obj .: "Hash"
+    linksSize      <- obj .: "LinksSize"
+    numLinks       <- obj .: "NumLinks"
+
+    return Stat {..}

--- a/library/Network/IPFS/Stat/Types.hs
+++ b/library/Network/IPFS/Stat/Types.hs
@@ -1,14 +1,15 @@
 module Network.IPFS.Stat.Types (Stat(..)) where
 
 import Network.IPFS.Prelude
+import Network.IPFS.Bytes.Types
 
 
 data Stat = Stat 
-  { blockSize      :: Natural
-  , cumulativeSize :: Natural
-  , dataSize       :: Natural
+  { blockSize      :: Bytes
+  , cumulativeSize :: Bytes
+  , dataSize       :: Bytes
   , hash           :: Text
-  , linksSize      :: Natural
+  , linksSize      :: Bytes
   , numLinks       :: Natural
   }
 

--- a/library/Network/IPFS/Types.hs
+++ b/library/Network/IPFS/Types.hs
@@ -16,6 +16,7 @@ module Network.IPFS.Types
   , Ignored
   , Gateway (..)
   , ErrorBody (..)
+  , Stat (..)
   ) where
 
 import Network.IPFS.BinPath.Types
@@ -30,3 +31,4 @@ import Network.IPFS.URL.Types
 import Network.IPFS.Ignored.Types
 import Network.IPFS.Gateway.Types
 import Network.IPFS.Client.Error.Types
+import Network.IPFS.Stat.Types

--- a/library/Network/IPFS/Types.hs
+++ b/library/Network/IPFS/Types.hs
@@ -17,6 +17,7 @@ module Network.IPFS.Types
   , Gateway (..)
   , ErrorBody (..)
   , Stat (..)
+  , Bytes (..)
   ) where
 
 import Network.IPFS.BinPath.Types
@@ -32,3 +33,4 @@ import Network.IPFS.Ignored.Types
 import Network.IPFS.Gateway.Types
 import Network.IPFS.Client.Error.Types
 import Network.IPFS.Stat.Types
+import Network.IPFS.Bytes.Types


### PR DESCRIPTION
## Problem
There is no way to access stat information about an ipfs object through the HTTP interface

## Solution
Add `/object/stat` route to ipfs remote api

#### Other consideration
Should we make the remote Monad mirror the local monad more closely such that the monad only has the one function (`runRemote` in this case) instead of another function for every possible operation. I forget the reasoning behind this. Probably just that it was the first monad I rolled by hand :sweat_smile: 