### PR TITLE
File.Serialized no longer requires UTF8 for PlainText

### DIFF
--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -60,6 +60,7 @@ library
       Network.IPFS.Internal.Orphanage.Utf8Builder
       Network.IPFS.Internal.UTF8
       Network.IPFS.Local.Class
+      Network.IPFS.MIME.RawPlainText.Types
       Network.IPFS.Name.Types
       Network.IPFS.Path.Types
       Network.IPFS.Peer
@@ -92,6 +93,7 @@ library
     , bytestring
     , envy
     , flow
+    , http-media
     , ip
     , lens
     , monad-logger
@@ -125,6 +127,7 @@ test-suite fission-doctest
     , doctest
     , envy
     , flow
+    , http-media
     , ip
     , lens
     , lens-aeson

--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           ipfs
-version:        1.1.3.1
+version:        1.1.4.0
 synopsis:       Access IPFS locally and remotely
 description:    Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category:       Network

--- a/library/Network/IPFS/Client/Cat.hs
+++ b/library/Network/IPFS/Client/Cat.hs
@@ -2,10 +2,9 @@ module Network.IPFS.Client.Cat (API) where
 
 import Servant.API
 
-import qualified Network.IPFS.Client.Param as Param
-import qualified Network.IPFS.File.Types   as File
-
-import Network.IPFS.MIME.RawPlainText.Types
+import qualified Network.IPFS.Client.Param            as Param
+import qualified Network.IPFS.File.Types              as File
+import           Network.IPFS.MIME.RawPlainText.Types
 
 -- IPFS v0.5 disallows GET requests
 -- https://docs.ipfs.io/recent-releases/go-ipfs-0-5/#breaking-changes-upgrade-notes

--- a/library/Network/IPFS/Client/Cat.hs
+++ b/library/Network/IPFS/Client/Cat.hs
@@ -1,11 +1,13 @@
 module Network.IPFS.Client.Cat (API) where
 
-import Servant
+import Servant.API
 
 import qualified Network.IPFS.Client.Param as Param
 import qualified Network.IPFS.File.Types   as File
 
+import Network.IPFS.MIME.RawPlainText.Types
+
 -- IPFS v0.5 disallows GET requests
 -- https://docs.ipfs.io/recent-releases/go-ipfs-0-5/#breaking-changes-upgrade-notes
 type API = Param.CID
-        :> Post '[PlainText] File.Serialized
+        :> Post '[PlainText, RawPlainText] File.Serialized

--- a/library/Network/IPFS/File/Types.hs
+++ b/library/Network/IPFS/File/Types.hs
@@ -4,8 +4,10 @@ module Network.IPFS.File.Types (Serialized (..)) where
 import qualified Data.ByteString.Builder as Builder
 import           Data.Swagger
 import qualified RIO.ByteString.Lazy     as Lazy
-import           Servant.API
 
+import Servant.API
+
+import Network.IPFS.MIME.RawPlainText.Types
 import Network.IPFS.Prelude
 
 -- | A file serialized as a lazy bytestring
@@ -27,14 +29,25 @@ instance ToSchema Serialized where
 instance Display Serialized where
   display = Utf8Builder . Builder.lazyByteString . unserialize
 
+-----
+
 instance MimeRender PlainText Serialized where
   mimeRender _proxy = unserialize
 
-instance MimeUnrender PlainText Serialized where
-  mimeUnrender _proxy = Right . Serialized
+instance MimeRender RawPlainText Serialized where
+  mimeRender _proxy = unserialize
 
 instance MimeRender OctetStream Serialized where
   mimeRender _proxy = unserialize
 
+-----
+
+instance MimeUnrender PlainText Serialized where
+  mimeUnrender _proxy = Right . Serialized
+
+instance MimeUnrender RawPlainText Serialized where
+  mimeUnrender _proxy = Right . Serialized
+
 instance MimeUnrender OctetStream Serialized where
   mimeUnrender _proxy = Right . Serialized
+

--- a/library/Network/IPFS/File/Types.hs
+++ b/library/Network/IPFS/File/Types.hs
@@ -50,4 +50,3 @@ instance MimeUnrender RawPlainText Serialized where
 
 instance MimeUnrender OctetStream Serialized where
   mimeUnrender _proxy = Right . Serialized
-

--- a/library/Network/IPFS/MIME/RawPlainText/Types.hs
+++ b/library/Network/IPFS/MIME/RawPlainText/Types.hs
@@ -1,0 +1,35 @@
+module Network.IPFS.MIME.RawPlainText.Types (RawPlainText) where
+
+import           Network.HTTP.Media
+import qualified Servant.API        as API
+
+import           RIO
+import qualified RIO.ByteString.Lazy as Lazy
+
+-- Built-in version includes charset
+-- https://github.com/haskell-servant/servant/issues/1002
+data RawPlainText
+
+instance API.Accept RawPlainText where
+  contentType _ = "text" // "plain"
+
+instance API.MimeRender RawPlainText Text where
+  mimeRender _ = Lazy.fromStrict . encodeUtf8
+
+instance API.MimeRender RawPlainText ByteString where
+  mimeRender _ = Lazy.fromStrict
+
+instance API.MimeRender RawPlainText Lazy.ByteString where
+  mimeRender _ = id
+
+instance API.MimeUnrender RawPlainText Text where
+  mimeUnrender _ bs =
+    case decodeUtf8' $ Lazy.toStrict bs of
+      Left  err -> Left $ show err
+      Right txt -> Right txt
+
+instance API.MimeUnrender RawPlainText ByteString where
+  mimeUnrender _ = Right . Lazy.toStrict
+
+instance API.MimeUnrender RawPlainText Lazy.ByteString where
+  mimeUnrender _ = Right

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: ipfs
-version: '1.1.3.1'
+version: '1.1.4.0'
 synopsis: Access IPFS locally and remotely
 description: Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category: Network
@@ -84,6 +84,7 @@ dependencies:
   - envy
   - flow
   - Glob
+  - http-media
   - ip
   - lens
   - monad-logger


### PR DESCRIPTION
Servant expects the charset to be present on plaintext requests: https://github.com/haskell-servant/servant/issues/1002

Charsets are technically optional, but strongly encouraged, especially in this age of UTF8.