### PR TITLE
Fix license references to match license file

### DIFF
--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -18,7 +18,7 @@ maintainer:     brooklyn@fission.codes,
                 daniel@fission.codes,
                 steven@fission.codes
 copyright:      © 2020 Fission Internet Software Services for Open Networks Inc.
-license:        AGPL-3.0-or-later
+license:        Apache-2.0
 license-file:   LICENSE
 tested-with:    GHC==8.6.5
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,7 @@ maintainer:
   - daniel@fission.codes
   - steven@fission.codes
 copyright: © 2020 Fission Internet Software Services for Open Networks Inc.
-license: AGPL-3.0-or-later
+license: Apache-2.0
 license-file: LICENSE
 github: fission-suite/ipfs-haskell
 tested-with: GHC==8.6.5


### PR DESCRIPTION
The LICENSE is Apache 2.0, but references to the license in ipfs.cabal and package.yaml say that the license is AGLP 3.0.