### PR TITLE
Escape paths

### DIFF
--- a/ipfs.cabal
+++ b/ipfs.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           ipfs
-version:        1.3.1
+version:        1.3.2
 synopsis:       Access IPFS locally and remotely
 description:    Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category:       Network
@@ -24,7 +24,7 @@ license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC==8.10.4
+    GHC==8.10.5
 extra-source-files:
     README.md
 
@@ -69,6 +69,8 @@ library
       Network.IPFS.Local.Class
       Network.IPFS.MIME.RawPlainText.Types
       Network.IPFS.Name.Types
+      Network.IPFS.Path.Escaped
+      Network.IPFS.Path.Escaped.Types
       Network.IPFS.Path.Types
       Network.IPFS.Peer
       Network.IPFS.Peer.Error

--- a/library/Network/IPFS/Add.hs
+++ b/library/Network/IPFS/Add.hs
@@ -93,9 +93,11 @@ addDir ::
   -> FilePath
   -> m (Either IPFS.Add.Error IPFS.CID)
 addDir ignored path =
-  doesFileExist path >>= \case
-    True  -> addPath path
-    False -> walkDir ignored path
+  doesFileExist path' >>= \case
+    True  -> addPath path'
+    False -> walkDir ignored path'
+  where
+    path' = Path.escape path
 
 walkDir ::
   ( MonadIO m

--- a/library/Network/IPFS/Local/Class.hs
+++ b/library/Network/IPFS/Local/Class.hs
@@ -3,15 +3,12 @@ module Network.IPFS.Local.Class
   , runLocal
   ) where
 
-import Network.IPFS.Prelude
+import           Network.IPFS.Prelude
 
-import qualified RIO.ByteString.Lazy as Lazy
+import qualified RIO.ByteString.Lazy        as Lazy
 
-import           Network.IPFS.Types         as IPFS
 import qualified Network.IPFS.Process.Error as Process
+import           Network.IPFS.Types         as IPFS
 
 class Monad m => MonadLocalIPFS m where
-  runLocal ::
-       [Opt]
-    -> Lazy.ByteString
-    -> m (Either Process.Error Process.RawMessage)
+  runLocal :: [Opt] -> Lazy.ByteString -> m (Either Process.Error Process.RawMessage)

--- a/library/Network/IPFS/Name/Types.hs
+++ b/library/Network/IPFS/Name/Types.hs
@@ -1,11 +1,11 @@
 module Network.IPFS.Name.Types (Name (..)) where
 
-import qualified RIO.Text as Text
+import qualified RIO.Text             as Text
 
-import Servant
-import Data.Swagger (ToParamSchema, ToSchema (..))
+import           Data.Swagger         (ToParamSchema, ToSchema (..))
+import           Servant
 
-import Network.IPFS.Prelude
+import           Network.IPFS.Prelude
 
 newtype Name = Name { unName :: String }
   deriving          ( Eq
@@ -30,4 +30,4 @@ instance FromJSON Name where
 instance FromHttpApiData Name where
   parseUrlPiece = \case
     ""  -> Left "Empty Name field"
-    txt -> Right . Name <| Text.unpack txt
+    txt -> Right . Name $ Text.unpack txt

--- a/library/Network/IPFS/Path/Escaped.hs
+++ b/library/Network/IPFS/Path/Escaped.hs
@@ -1,0 +1,11 @@
+module Network.IPFS.Path.Escaped
+  ( escape
+  , module Network.IPFS.Path.Escaped.Types
+  ) where
+
+import           Network.IPFS.Prelude
+
+import           Network.IPFS.Path.Escaped.Types
+
+escape :: FilePath -> FilePath
+escape path = show (fromString path :: Escaped)

--- a/library/Network/IPFS/Path/Escaped/Types.hs
+++ b/library/Network/IPFS/Path/Escaped/Types.hs
@@ -1,0 +1,31 @@
+-- |
+
+module Network.IPFS.Path.Escaped.Types (Escaped (..)) where
+
+-- import           Data.Swagger               (ToSchema (..))
+-- import           Servant
+--
+-- import qualified Network.IPFS.Internal.UTF8 as UTF8
+import           Network.IPFS.Prelude
+
+-- | Verbatim file path, includes spaces
+--
+-- Exmaple
+--
+-- > "~/Desktop/foo bar/baz.png"
+newtype Escaped = Escaped { unescape :: Text }
+  deriving          ( Eq
+                    , Generic
+                    , Ord
+                    , Show
+                    )
+  deriving newtype  ( IsString
+                    -- , ToHttpApiData
+                    -- , ToSchema
+                    )
+
+-- instance MimeRender PlainText Escaped where
+  -- mimeRender _ = UTF8.textToLazyBS . unescape
+
+-- instance MimeRender OctetStream Escaped where
+  -- mimeRender _ = UTF8.textToLazyBS . unescape

--- a/library/Network/IPFS/SparseTree.hs
+++ b/library/Network/IPFS/SparseTree.hs
@@ -5,9 +5,9 @@ module Network.IPFS.SparseTree
   , cIDs
   ) where
 
+import qualified Network.IPFS.Error            as Error
+import qualified Network.IPFS.Internal.UTF8    as UTF8
 import           Network.IPFS.Prelude
-import qualified Network.IPFS.Internal.UTF8 as UTF8
-import qualified Network.IPFS.Error    as Error
 
 import           Network.IPFS.CID.Types
 import           Network.IPFS.Name.Types
@@ -17,20 +17,21 @@ import           Network.IPFS.SparseTree.Types
 linearize :: SparseTree -> Either Error.Linearization Path
 linearize = fmap Path . go
   where
-  go :: SparseTree -> Either Error.Linearization Text
-  go = \case
-    Stub      (Name name)    -> Right <| UTF8.textShow name
-    Content   (CID _)        -> Right ""
-    Directory [(tag, value)] -> fromPath tag <$> go value
-    badDir                   -> Left <| Error.NonLinear badDir
-    where
-      fromPath tag ""   = fromKey tag
-      fromPath tag text = fromKey tag <> "/" <> text
+    go :: SparseTree -> Either Error.Linearization Text
+    go = \case
+      Stub      (Name name)    -> Right $ UTF8.textShow name
+      Content   (CID _)        -> Right ""
+      Directory [(tag, value)] -> fromPath tag <$> go value
+      badDir                   -> Left $ Error.NonLinear badDir
+      where
+        fromPath tag ""   = fromKey tag
+        fromPath tag text = fromKey tag <> "/" <> text
 
-      fromKey :: Tag -> Text
-      fromKey = UTF8.stripN 1 . \case
-        Hash (CID cid)   -> cid
-        Key  (Name name) -> UTF8.textShow name
+        fromKey :: Tag -> Text
+        fromKey =
+          UTF8.stripN 1 . \case
+            Hash (CID cid)   -> cid
+            Key  (Name name) -> UTF8.textShow name
 
 -- | Get all CIDs from a 'SparseTree' (all levels)
 cIDs :: (Monoid (f CID), Applicative f) => SparseTree -> f CID

--- a/library/Network/IPFS/SparseTree/Types.hs
+++ b/library/Network/IPFS/SparseTree/Types.hs
@@ -3,17 +3,17 @@ module Network.IPFS.SparseTree.Types
   , Tag (..)
   ) where
 
-import qualified RIO.HashMap as HashMap
-import qualified RIO.Map     as Map
-import qualified RIO.Text    as Text
+import qualified RIO.HashMap                as HashMap
+import qualified RIO.Map                    as Map
+import qualified RIO.Text                   as Text
 
-import Data.Swagger hiding (Tag, name)
-import Servant
+import           Data.Swagger               hiding (Tag, name)
+import           Servant
 
-import           Network.IPFS.Prelude
-import qualified Network.IPFS.Internal.UTF8 as UTF8
 import           Network.IPFS.CID.Types
+import qualified Network.IPFS.Internal.UTF8 as UTF8
 import           Network.IPFS.Name.Types
+import           Network.IPFS.Prelude
 
 -- | Directory structure for CIDs and other identifiers
 --
@@ -55,9 +55,9 @@ instance Display SparseTree where
 
 instance ToJSON SparseTree where
   toJSON = \case
-    Stub (Name name)  -> String <| Text.pack name
-    Content (CID cid) -> String <| UTF8.stripN 1 cid
-    Directory dirMap  -> Object <| HashMap.fromList (jsonKV <$> Map.toList dirMap)
+    Stub (Name name)  -> String $ Text.pack name
+    Content (CID cid) -> String $ UTF8.stripN 1 cid
+    Directory dirMap  -> Object $ HashMap.fromList (jsonKV <$> Map.toList dirMap)
     where
       jsonKV :: (Tag, SparseTree) -> (Text, Value)
       jsonKV (tag, subtree) = (jsonTag tag, toJSON subtree)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: ipfs
-version: '1.3.1'
+version: '1.3.2'
 synopsis: Access IPFS locally and remotely
 description: Interact with the IPFS network by shelling out to a local IPFS node or communicating via the HTTP interface of a remote IPFS node.
 category: Network
@@ -17,7 +17,7 @@ copyright: © 2021 Fission Internet Software Services for Open Networks Inc.
 license: Apache-2.0
 license-file: LICENSE
 github: fission-suite/ipfs-haskell
-tested-with: GHC==8.10.4
+tested-with: GHC==8.10.5
 extra-source-files:
   - README.md
 


### PR DESCRIPTION
Paths, especially directories, that contain spaces fail when pushed over `stdin` since they're treated as multiple arguments. This adds quotes around these strings to treat them verbatim. In future, we may want to add HTTP escaping for Servant instances as well, but we haven't bumped into this yet.